### PR TITLE
Fix IPv6 server address handling

### DIFF
--- a/potter.go
+++ b/potter.go
@@ -102,7 +102,7 @@ func main() {
 
 	// SSH server config
 	s := &ssh.Server{
-		Addr:                 *ssh_ip + ":" + *ssh_port,
+		Addr:                 net.JoinHostPort(*ssh_ip, *ssh_port),
 		Version:              *ssh_string,
 		IdleTimeout:          time.Duration(10 * time.Second),
 		MaxTimeout:           time.Duration(15 * time.Second),


### PR DESCRIPTION
## Summary
- use `net.JoinHostPort` when constructing `ssh.Server.Addr`
- keep `net` in imports

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68400a3f9b3c83329426f1d504069dfb