### PR TITLE
Replace ioutil.ReadFile with os.ReadFile

### DIFF
--- a/potter.go
+++ b/potter.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -91,7 +90,7 @@ func main() {
 	mac = strings.Split(*mac_flag, ",")
 
 	// Open hostkey file
-	keyb, err := ioutil.ReadFile(*ssh_hostkey)
+	keyb, err := os.ReadFile(*ssh_hostkey)
 	if err != nil {
 		log.Fatalf("Failed to open hostkey: %s.", *ssh_hostkey)
 	}


### PR DESCRIPTION
## Summary
- drop deprecated `io/ioutil` usage
- use `os.ReadFile` in `main`

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68400a4fca408332a6bc447a65da1c36